### PR TITLE
Add commands to configure various upstream timeouts.

### DIFF
--- a/ngx_http_websockify_module.c
+++ b/ngx_http_websockify_module.c
@@ -459,12 +459,34 @@ static ngx_command_t ngx_http_websockify_commands[] = {
         NGX_HTTP_LOC_CONF_OFFSET,
         0,
         NULL },
+
     { ngx_string("websockify_buffer_size"),
-          NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-          ngx_conf_set_size_slot,
-          NGX_HTTP_LOC_CONF_OFFSET,
-          offsetof(ngx_http_websockify_loc_conf_t, upstream.buffer_size),
-          NULL }, 
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_size_slot,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_websockify_loc_conf_t, upstream.buffer_size),
+        NULL }, 
+
+    { ngx_string("websockify_connect_timeout"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_msec_slot,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_websockify_loc_conf_t, upstream.connect_timeout),
+        NULL },
+
+    { ngx_string("websockify_send_timeout"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_msec_slot,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_websockify_loc_conf_t, upstream.send_timeout),
+        NULL },
+
+    { ngx_string("websockify_read_timeout"),
+        NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_msec_slot,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        offsetof(ngx_http_websockify_loc_conf_t, upstream.read_timeout),
+        NULL },
     
     ngx_null_command
 };


### PR DESCRIPTION
This change allows the upstream timeouts connect_timeout, send_timeout, and read_timeout to be configured using websockify_connect_timeout, websockify_send_timeout, and websockify_read_timeout.
